### PR TITLE
Force callback to run async

### DIFF
--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -98,7 +98,11 @@ function express:_put( data, cb )
 
     local cachedId = self._putCache[hash]
     if cachedId then
-        cb( cachedId, hash )
+        -- Force the callback to run asynchronously for consistency
+        timer.Simple( 0, function()
+            cb( cachedId, hash )
+        end )
+
         return
     end
 


### PR DESCRIPTION
If a message has already been uploaded, we want to call the given callback asynchronously to be consistent with the uncached behavior.