### PR TITLE
Support Selfhosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,7 @@ Doing it this way comes with a number of practical benefits:
 Express works by storing the data you send on Cloudflare's Edge servers. Using Cloudflare workers, KV, and D1, Express can cheaply serve millions of requests and store hundreds of gigabytes per month. Cloudflare's Edge servers offer extremely low-latency requests and data access to every corner of the globe.
 
 By default, Express uses a free-forever public API provided by CFC Servers, but anyone can easily host their own!
-<details>
-<summary>Click here to learn more</summary>
-
-<br>
-
-[The Express Service](https://github.com/CFC-Servers/gm_express_service) is a Cloudflare Workers project, meaning that all of the code runs on Cloudflare's Edge servers.
-All data is stored using Cloudflare's K/V system - an ultra low-latency key-value storage tool that enables Express to send large chunks of data as quickly as your internet connection will allow.
-
-If you'd like to host your own Service, just click this button!
-
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button?paid=true)](https://deploy.workers.cloudflare.com/?url=https://github.com/CFC-Servers/gm_express_service&paid=true)
-
-**Note:** You'll also need to update the `express_domain` convar to whatever your new domain is. By default it'll probably look like: `gmod-express.<your cloudflare username>.workers.dev`. _(Don't include the protocol, just the raw domain)_
-
-</details>
+Check out the [Express Service](https://github.com/CFC-Servers/gm_express_service) README for more information.
 
 ## Usage
 

--- a/lua/autorun/gm_express_init.lua
+++ b/lua/autorun/gm_express_init.lua
@@ -1,3 +1,2 @@
 AddCSLuaFile( "includes/modules/pon.lua" )
-AddCSLuaFile( "includes/modules/playerload.lua" )
 include( "gm_express/sh_init.lua" )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -18,6 +18,12 @@ express.domain = CreateConVar(
     "express_domain", "gmod.express", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The domain of the Express server"
 )
 
+-- Useful for self-hosting if you need to set express_domain to localhost
+-- and direct clients to a global IP/domain to hit the same service
+express.domain_cl = CreateConVar(
+    "express_domain_cl", "", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The client-specific domain of the Express server. If empty, express_domain will be used."
+)
+
 
 -- Registers a basic receiver --
 function express.Receive( message, cb )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -16,7 +16,6 @@ function express.Register()
     local oneDay = 60 * 60 * 24
     timer.Create( "Express_Register", oneDay, 0, express.Register )
 
-    express._putCache = {}
     local url = express:makeBaseURL() .. "/register"
 
     http.Fetch( url, function( body, _, _, code )

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -33,6 +33,9 @@ return {
                 expect( express.domain ).to.exist()
                 expect( tostring( express.domain ) ).to.equal( tostring( GetConVar( "express_domain" ) ) )
 
+                expect( express.domain_cl ).to.exist()
+                expect( tostring( express.domain_cl ) ).to.equal( tostring( GetConVar( "express_domain_cl" ) ) )
+
                 expect( net.Receivers["express"] ).to.exist()
                 expect( net.Receivers["express_proof"] ).to.exist()
             end


### PR DESCRIPTION
This PR makes a few changes to better support self-hosting the Express Service.

In summary:
 - Fixes a bug where clients wouldn't clear their `_putCache` when the Express Domain changed
 - Fixed a mistake where the serverside PlayerFullLoad library was being sent to Clients
 - Added the `express_domain_cl` convar that allows operators to set a different Express domain for clients (ideal for self-hosting)