### PR TITLE
Set longer HTTP timeouts on Client

### DIFF
--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -158,6 +158,11 @@ function express:_getPreDlReceiver( message )
 end
 
 
+-- Returns a realm-specific timeout value for HTTP requests --
+function express:_getTimeout()
+    return CLIENT and 240 or 60
+end
+
 
 -- Ensures that the given HTTP response code indicates a succcessful request --
 function express._checkResponseCode( code )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -54,7 +54,14 @@ function express:Get( id, cb )
         cb( decodedData, hash )
     end
 
-    http.Fetch( url, success, error, self._bytesHeaders )
+    HTTP( {
+        method = "GET",
+        url = url,
+        success = success,
+        failed = error,
+        headers = self._bytesHeaders,
+        timeout = self:_getTimeout()
+    } )
 end
 
 
@@ -74,7 +81,14 @@ function express:GetSize( id, cb )
         cb( tonumber( size ) )
     end
 
-    http.Fetch( url, success, error, self._jsonHeaders )
+    HTTP( {
+        method = "GET",
+        url = url,
+        success = success,
+        failed = error,
+        headers = self._jsonHeaders,
+        timeout = self:_getTimeout()
+    } )
 end
 
 
@@ -100,7 +114,8 @@ function express:Put( data, cb )
             ["Content-Length"] = #data,
             ["Accept"] = "application/json"
         },
-        type = "application/octet-stream"
+        type = "application/octet-stream",
+        timeout = CLIENT and 240 or 60
     } )
 end
 

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -33,8 +33,8 @@ return {
 
                 express.shSend()
 
-                expect( send ).notTo.haveBeenCalled()
-                expect( sendToServer ).to.haveBeenCalled()
+                expect( send ).wasNot.called()
+                expect( sendToServer ).was.called()
             end,
 
             cleanup = function()
@@ -51,8 +51,8 @@ return {
 
                 express.shSend()
 
-                expect( send ).to.haveBeenCalled()
-                expect( sendToServer ).notTo.haveBeenCalled()
+                expect( send ).was.called()
+                expect( sendToServer ).wasNot.called()
             end
         },
 
@@ -224,7 +224,7 @@ return {
                 express._waitingForAccess = { waitingStub }
 
                 express:SetAccess( "access-token" )
-                expect( waitingStub ).to.haveBeenCalled()
+                expect( waitingStub ).was.called()
                 expect( #express._waitingForAccess ).to.equal( 0 )
             end,
 
@@ -243,7 +243,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end
         },
         {
@@ -257,7 +257,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end
         },
         {
@@ -271,7 +271,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end
         },
         {
@@ -287,7 +287,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end
         },
         {
@@ -306,7 +306,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end,
 
             cleanup = function( state )
@@ -327,7 +327,7 @@ return {
                 end )
 
                 express.CheckRevision()
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( fetchStub ).was.called()
             end,
 
             cleanup = function( state )
@@ -348,7 +348,7 @@ return {
                 local getStub = stub( express, "Get" )
                 express:_get( "id", "callback" )
 
-                expect( getStub ).to.haveBeenCalled()
+                expect( getStub ).was.called()
                 expect( #express._waitingForAccess ).to.equal( 0 )
             end,
             cleanup = function( state )
@@ -367,7 +367,7 @@ return {
                 local getStub = stub( express, "Get" )
                 express:_get( "id", "callback" )
 
-                expect( getStub ).notTo.haveBeenCalled()
+                expect( getStub ).wasNot.called()
                 expect( #express._waitingForAccess ).to.equal( 1 )
             end,
             cleanup = function( state )
@@ -389,9 +389,9 @@ return {
 
                 express:_put( "data", "callback" )
 
-                expect( encode ).to.haveBeenCalled()
-                expect( compress ).to.haveBeenCalled()
-                expect( putStub ).to.haveBeenCalled()
+                expect( encode ).was.called()
+                expect( compress ).was.called()
+                expect( putStub ).was.called()
             end
         },
         {
@@ -414,7 +414,7 @@ return {
                     "Express: Data too large (" .. expectedBytes .. " bytes)"
                 )
 
-                expect( putStub ).notTo.haveBeenCalled()
+                expect( putStub ).wasNot.called()
             end,
 
             cleanup = function( state )
@@ -444,8 +444,8 @@ return {
                 express:_put( mockData, mockCallback )
 
                 timer.Simple( 0.1, function()
-                    expect( putStub ).notTo.haveBeenCalled()
-                    expect( mockCallback ).to.haveBeenCalled()
+                    expect( putStub ).wasNot.called()
+                    expect( mockCallback ).was.called()
                     done()
                 end )
             end,
@@ -474,8 +474,8 @@ return {
 
                 express:_put( mockData, mockCallback )
 
-                expect( putStub ).to.haveBeenCalled()
-                expect( mockCallback ).to.haveBeenCalled()
+                expect( putStub ).was.called()
+                expect( mockCallback ).was.called()
                 expect( express._putCache[mockHash] ).to.equal( mockId )
             end,
 
@@ -500,9 +500,9 @@ return {
 
                 express:_send( "test-message", "test-data", {} )
 
-                expect( putStub ).to.haveBeenCalled()
-                expect( setExpected ).notTo.haveBeenCalled()
-                expect( shSend ).to.haveBeenCalled()
+                expect( putStub ).was.called()
+                expect( setExpected ).wasNot.called()
+                expect( shSend ).was.called()
             end
         },
         {
@@ -520,9 +520,9 @@ return {
 
                 express:_send( "test-message", "test-data", {}, stub() )
 
-                expect( putStub ).to.haveBeenCalled()
-                expect( setExpected ).to.haveBeenCalled()
-                expect( shSend ).to.haveBeenCalled()
+                expect( putStub ).was.called()
+                expect( setExpected ).was.called()
+                expect( shSend ).was.called()
             end
         },
 
@@ -641,8 +641,8 @@ return {
 
                 callbackFunc()
 
-                expect( registerStub ).to.haveBeenCalled()
-                expect( checkRevisionStub ).to.haveBeenCalled()
+                expect( registerStub ).was.called()
+                expect( checkRevisionStub ).was.called()
             end
         },
 

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -670,7 +670,29 @@ return {
             func = function()
                 expect( express._checkResponseCode, nil ).to.errWith( "Express: Invalid response code (nil)" )
             end
-        }
+        },
 
+        -- express._getTimeout
+        {
+            name = "express._getTimeout returns 240 on CLIENT",
+            func = function()
+                _G.CLIENT = true
+                _G.SERVER = false
+
+                local timeout = express:_getTimeout()
+                expect( timeout ).to.equal( 240 )
+            end,
+            cleanup = function()
+                _G.CLIENT = false
+                _G.SERVER = true
+            end
+        },
+        {
+            name = "express._getTimeout returns 60 on SERVER",
+            func = function()
+                local timeout = express:_getTimeout()
+                expect( timeout ).to.equal( 60 )
+            end
+        }
     }
 }

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -81,13 +81,13 @@ return {
         {
             name = "express.Get errors if the request fails",
             func = function()
-                local fetchStub = stub( http, "Fetch" ).with( function( _, _, errorCb )
-                    expect( errorCb ).to.equal( error )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.failed ).to.equal( error )
                 end )
 
                 express:Get( "test-id", stub() )
 
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
             end
         },
         {
@@ -95,14 +95,14 @@ return {
             func = function()
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
                 end )
 
                 express:Get( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -113,14 +113,14 @@ return {
 
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 200 ).to.errWith( "Invalid data" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, "", "", "", 200 ).to.errWith( "Invalid data" )
                 end )
 
                 express:Get( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -132,14 +132,14 @@ return {
 
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    success( "", "", "", 200 )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    options.success( "", "", "", 200 )
                 end )
 
                 express:Get( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).was.called()
             end
         },
 
@@ -147,13 +147,13 @@ return {
         {
             name = "express.GetSize errors if the request fails",
             func = function()
-                local fetchStub = stub( http, "Fetch" ).with( function( _, _, errorCb )
-                    expect( errorCb ).to.equal( error )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.failed ).to.equal( error )
                 end )
 
                 express:GetSize( "test-id", stub() )
 
-                expect( fetchStub ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
             end
         },
         {
@@ -161,14 +161,14 @@ return {
             func = function()
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
                 end )
 
                 express:GetSize( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -178,14 +178,14 @@ return {
 
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 200 ).to.errWith( "Invalid JSON" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, "", "", "", 200 ).to.errWith( "Invalid JSON" )
                 end )
 
                 express:GetSize( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -195,14 +195,14 @@ return {
 
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 200 ).to.errWith( "No size data" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, "", "", "", 200 ).to.errWith( "No size data" )
                 end )
 
                 express:GetSize( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -212,14 +212,14 @@ return {
 
                 local callback = stub()
 
-                local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    success( "", "", "", 200 )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    options.success( "", "", "", 200 )
                 end )
 
                 express:GetSize( "test-id", callback )
 
-                expect( fetchStub ).to.haveBeenCalled()
-                expect( callback ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).was.called()
             end
         },
 
@@ -227,13 +227,13 @@ return {
         {
             name = "express.Put errors if the request fails",
             func = function()
-                local httpStub = stub( _G, "HTTP" ).with( function( reqData )
-                    expect( reqData.failed ).to.equal( error )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.failed ).to.equal( error )
                 end )
 
                 express:Put( "test-data", stub() )
 
-                expect( httpStub ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
             end
         },
         {
@@ -241,14 +241,14 @@ return {
             func = function()
                 local callback = stub()
 
-                local httpStub = stub( _G, "HTTP" ).with( function( reqData )
-                    expect( reqData.success, 418, "" ).to.errWith( "Invalid response code: 418" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, 418, "" ).to.errWith( "Invalid response code: 418" )
                 end )
 
                 express:Put( "test-data", callback )
 
-                expect( httpStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -258,14 +258,14 @@ return {
 
                 local callback = stub()
 
-                local httpStub = stub( _G, "HTTP" ).with( function( reqData )
-                    expect( reqData.success, 200, "" ).to.errWith( "Invalid JSON" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, 200, "" ).to.errWith( "Invalid JSON" )
                 end )
 
                 express:Put( "test-data", callback )
 
-                expect( httpStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -275,14 +275,14 @@ return {
 
                 local callback = stub()
 
-                local httpStub = stub( _G, "HTTP" ).with( function( reqData )
-                    expect( reqData.success, 200, "" ).to.errWith( "No ID returned" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    expect( options.success, 200, "" ).to.errWith( "No ID returned" )
                 end )
 
                 express:Put( "test-data", callback )
 
-                expect( httpStub ).to.haveBeenCalled()
-                expect( callback ).notTo.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).wasNot.called()
             end
         },
         {
@@ -292,14 +292,14 @@ return {
 
                 local callback = stub()
 
-                local httpStub = stub( _G, "HTTP" ).with( function( reqData )
-                    reqData.success( 200, "" )
+                local httpStub = stub( _G, "HTTP" ).with( function( options )
+                    options.success( 200, "" )
                 end )
 
                 express:Put( "test-data", callback )
 
-                expect( httpStub ).to.haveBeenCalled()
-                expect( callback ).to.haveBeenCalled()
+                expect( httpStub ).was.called()
+                expect( callback ).was.called()
             end
         },
 
@@ -311,7 +311,7 @@ return {
                 stub( express, "_getReceiver" ).returns( callback )
 
                 express:Call( "test-message" )
-                expect( callback ).to.haveBeenCalled()
+                expect( callback ).was.called()
             end
         },
 
@@ -323,7 +323,7 @@ return {
                 stub( express, "_getPreDlReceiver" ).returns( callback )
 
                 express:CallPreDownload( "test-message" )
-                expect( callback ).to.haveBeenCalled()
+                expect( callback ).was.called()
             end
         },
 
@@ -356,7 +356,7 @@ return {
 
                 express:OnMessage()
 
-                expect( getSizeStub ).to.haveBeenCalled()
+                expect( getSizeStub ).was.called()
             end
         },
         {
@@ -373,7 +373,7 @@ return {
 
                 express:OnMessage()
 
-                expect( getSizeStub ).notTo.haveBeenCalled()
+                expect( getSizeStub ).wasNot.called()
             end
         },
         {


### PR DESCRIPTION
This addresses https://github.com/CFC-Servers/gm_express/issues/18 in a pretty direct way, but I'm not sure I'll be comfortable closing the issue until we get some more data.

~~Note: This uses new GLuaTest syntax that will be released later today, so the checks will fail when this PR first opens.~~