### PR TITLE
Handle nil response codes

### DIFF
--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -159,6 +159,15 @@ end
 
 
 
+-- Ensures that the given HTTP response code indicates a succcessful request --
+function express:_checkResponseCode( code )
+    local isOk = isnumber( code ) and code >= 200 and code < 300
+    if isOk then return end
+
+    error( "Express: Invalid response code (" .. code .. ")" )
+end
+
+
 -- Attempts to re-register with the new domain, and then verifies its version --
 cvars.AddChangeCallback( "express_domain", function()
     express._putCache = {}

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -160,11 +160,11 @@ end
 
 
 -- Ensures that the given HTTP response code indicates a succcessful request --
-function express:_checkResponseCode( code )
+function express._checkResponseCode( code )
     local isOk = isnumber( code ) and code >= 200 and code < 300
     if isOk then return end
 
-    error( "Express: Invalid response code (" .. code .. ")" )
+    error( "Express: Invalid response code (" .. tostring( code ) .. ")" )
 end
 
 

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -44,7 +44,7 @@ function express:Get( id, cb )
     local url = self:makeAccessURL( "read", id )
 
     local success = function( body, _, _, code )
-        assert( code >= 200 and code < 300, "Invalid status code: " .. code )
+        express:_checkResponseCode( code )
 
         local hash = util.SHA1( body )
         local encodedData = util.Decompress( body, self._maxDataSize )
@@ -63,7 +63,7 @@ function express:GetSize( id, cb )
     local url = self:makeAccessURL( "size", id )
 
     local success = function( body, _, _, code )
-        assert( code >= 200 and code < 300, "Invalid status code: " .. code )
+        express:_checkResponseCode( code )
 
         local sizeHolder = util.JSONToTable( body )
         assert( sizeHolder, "Invalid JSON" )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -44,7 +44,7 @@ function express:Get( id, cb )
     local url = self:makeAccessURL( "read", id )
 
     local success = function( body, _, _, code )
-        express:_checkResponseCode( code )
+        express._checkResponseCode( code )
 
         local hash = util.SHA1( body )
         local encodedData = util.Decompress( body, self._maxDataSize )
@@ -63,7 +63,7 @@ function express:GetSize( id, cb )
     local url = self:makeAccessURL( "size", id )
 
     local success = function( body, _, _, code )
-        express:_checkResponseCode( code )
+        express._checkResponseCode( code )
 
         local sizeHolder = util.JSONToTable( body )
         assert( sizeHolder, "Invalid JSON" )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -19,7 +19,7 @@ function express.Register()
     local url = express:makeBaseURL() .. "/register"
 
     http.Fetch( url, function( body, _, _, code )
-        express:_checkResponseCode( code )
+        express._checkResponseCode( code )
 
         local response = util.JSONToTable( body )
         assert( response, "Invalid JSON" )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -19,7 +19,7 @@ function express.Register()
     local url = express:makeBaseURL() .. "/register"
 
     http.Fetch( url, function( body, _, _, code )
-        assert( code >= 200 and code < 300, "Invalid status code: " .. code )
+        express:_checkResponseCode( code )
 
         local response = util.JSONToTable( body )
         assert( response, "Invalid JSON" )

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -644,6 +644,32 @@ return {
                 expect( registerStub ).to.haveBeenCalled()
                 expect( checkRevisionStub ).to.haveBeenCalled()
             end
+        },
+
+        -- express:_checkResponseCode
+        {
+            name = "express._checkResponseCode succeeds if the response code is 200",
+            func = function()
+                expect( express._checkResponseCode, 200 ).to.succeed()
+            end
+        },
+        {
+            name = "express._checkResponseCode throws an error if the response code is under 200",
+            func = function()
+                expect( express._checkResponseCode, 199 ).to.errWith( "Express: Invalid response code (199)" )
+            end
+        },
+        {
+            name = "express._checkResponseCode throws an error if the response code is over 300",
+            func = function()
+                expect( express._checkResponseCode, 420 ).to.errWith( "Express: Invalid response code (420)" )
+            end
+        },
+        {
+            name = "express._checkResponseCode throws an error if the response code is nil",
+            func = function()
+                expect( express._checkResponseCode, nil ).to.errWith( "Express: Invalid response code (nil)" )
+            end
         }
 
     }

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -96,7 +96,7 @@ return {
                 local callback = stub()
 
                 local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 418 ).to.errWith( "Invalid status code: 418" )
+                    expect( success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
                 end )
 
                 express:Get( "test-id", callback )
@@ -162,7 +162,7 @@ return {
                 local callback = stub()
 
                 local fetchStub = stub( http, "Fetch" ).with( function( _, success )
-                    expect( success, "", "", "", 418 ).to.errWith( "Invalid status code: 418" )
+                    expect( success, "", "", "", 418 ).to.errWith( "Express: Invalid response code (418)" )
                 end )
 
                 express:GetSize( "test-id", callback )


### PR DESCRIPTION
Not sure why it happens, but the addon shouldn't produce obscure errors because of it.

I also took this opportunity to extract the status code checker into its own helper function, update the existing tests, and add new tests for the new method.