### PR TITLE
Add Load hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ end )
 </details>
 
 <details>
+<summary><h4> <strong><img src="https://user-images.githubusercontent.com/7936439/200705159-4c51d043-82a3-4d15-a335-291bb26a5528.png" width="15"> <code>express.ClearReceiver( string name )</code></strong> </h4></summary>
+
+#### <ins>**Description**</ins>
+Removes the callback associated with the given message name. Much like `net.Receive( message, nil )`.
+
+#### <ins>**Arguments**</ins>
+1. **`string name`**
+    - The name of the message. Think of this just like the name given to `net.Receive`
+    - This parameter is case-insensitive, it will be `string.lower`'d
+
+#### <ins>**Example**</ins>
+Create a new Receiver when the module is enabled, and remove the receiver when it's disabled
+```lua
+local function enable()
+    express.Receive( "example", processData )
+end
+
+local function disable()
+    express.ClearReceiver( "example" )
+end
+```
+</details>
+
+<details>
 <summary><h4> <strong><img src="https://user-images.githubusercontent.com/7936439/200705060-b5e57f56-a5a1-4c95-abfa-0d568be0aad6.png" width="15"> <code>express.Send( string name, table data, function onProof )</code></strong> </h4></summary>
 
 #### <ins>**Description**</ins>

--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -12,3 +12,9 @@ end
 function express:SetExpected( hash, cb )
     self._awaitingProof[hash] = cb
 end
+
+
+hook.Add( "OnExpressLoaded", "Express_AlertReady", function()
+    net.Start( "express_loaded" )
+    net.SendToServer()
+end )

--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -2,17 +2,17 @@ express._receiverMadeQueue = {}
 express._canSendReceiverMade = false
 
 
-hook.Add( "InitPostEntity", "Express_ReceiverMadeAlert", function()
+net.Receive( "express_access", function()
+    express:SetAccess( net.ReadString() )
+    express:_sendReceiversMadeQueue()
+end )
+
+function express:_sendReceiversMadeQueue()
     express._canSendReceiverMade = true
 
     local messages = table.GetKeys( express._receiverMadeQueue )
     express:_alertReceiversMade( unpack( messages ) )
-end )
-
-net.Receive( "express_access", function()
-    express:SetAccess( net.ReadString() )
-end )
-
+end
 
 function express:_alertReceiversMade( ... )
     local names = { ... }

--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -12,9 +12,3 @@ end
 function express:SetExpected( hash, cb )
     self._awaitingProof[hash] = cb
 end
-
-
-hook.Add( "OnExpressLoaded", "Express_AlertReady", function()
-    net.Start( "express_loaded" )
-    net.SendToServer()
-end )

--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -1,6 +1,45 @@
+express._receiverMadeQueue = {}
+express._canSendReceiverMade = false
+
+
+hook.Add( "InitPostEntity", "Express_ReceiverMadeAlert", function()
+    express._canSendReceiverMade = true
+
+    local messages = table.GetKeys( express._receiverMadeQueue )
+    express:_alertReceiversMade( unpack( messages ) )
+end )
+
 net.Receive( "express_access", function()
     express:SetAccess( net.ReadString() )
 end )
+
+
+function express:_alertReceiversMade( ... )
+    local names = { ... }
+    local receiverCount = #names
+
+    net.Start( "express_receivers_made" )
+    net.WriteUInt( receiverCount, 8 )
+
+    for i = 1, receiverCount do
+        net.WriteString( names[i] )
+    end
+
+    net.SendToServer()
+end
+
+
+-- Registers a basic receiver --
+function express.Receive( message, cb )
+    express:_setReceiver( message, cb )
+
+    if not express._canSendReceiverMade then
+        express._receiverMadeQueue[message] = true
+        return
+    end
+
+    express:_alertReceiversMade( message )
+end
 
 
 -- Calls the main _send function but passes nil for the recipient --

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -205,7 +205,7 @@ cvars.AddChangeCallback( "express_domain_cl", function( _, _, new )
 end, "domain_check" )
 
 
-hook.Run( "OnExpressLoaded", "Express_HTTPInit", function()
+hook.Add( "OnExpressLoaded", "Express_HTTPInit", function()
     hook.Add( "Tick", "Express_RevisionCheck", function()
         hook.Remove( "Tick", "Express_RevisionCheck" )
         if SERVER then express:Register() end

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -109,6 +109,7 @@ end
 
 
 -- Runs the main :GetSize function, or queues the request if no access token is set --
+-- FIXME: If this gets delayed because it doesn't have an access token, the PreDl Receiver will not be able to stop the download --
 function express:_getSize( id, cb )
     if self.access then
         return self:GetSize( id, cb )

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -3,6 +3,15 @@ express.version = 1
 express.revision = 1
 express._putCache = {}
 express._waitingForAccess = {}
+express.domain = CreateConVar(
+    "express_domain", "gmod.express", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The domain of the Express server"
+)
+
+-- Useful for self-hosting if you need to set express_domain to localhost
+-- and direct clients to a global IP/domain to hit the same service
+express.domain_cl = CreateConVar(
+    "express_domain_cl", "", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The client-specific domain of the Express server. If empty, express_domain will be used."
+)
 
 
 -- Runs the correct net Send function based on the realm --

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -196,9 +196,10 @@ cvars.AddChangeCallback( "express_domain_cl", function( _, _, new )
 end, "domain_check" )
 
 
--- Tick is the earliest shared hook where HTTP is available
-hook.Add( "Tick", "Express_RevisionCheck", function()
-    hook.Remove( "Tick", "Express_RevisionCheck" )
-    if SERVER then express:Register() end
-    express:CheckRevision()
+hook.Run( "OnExpressLoaded", "Express_HTTPInit", function()
+    hook.Add( "Tick", "Express_RevisionCheck", function()
+        hook.Remove( "Tick", "Express_RevisionCheck" )
+        if SERVER then express:Register() end
+        express:CheckRevision()
+    end )
 end )

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -108,6 +108,18 @@ function express:_get( id, cb )
 end
 
 
+-- Runs the main :GetSize function, or queues the request if no access token is set --
+function express:_getSize( id, cb )
+    if self.access then
+        return self:GetSize( id, cb )
+    end
+
+    table.insert( self._waitingForAccess, function()
+        self:GetSize( id, cb )
+    end )
+end
+
+
 -- Encodes and compresses the given data, then sends it to the API if not already cached --
 function express:_put( data, cb )
     if table.Count( data ) == 0 then

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -137,7 +137,13 @@ function express:_put( data, cb )
         cb( id, hash )
     end
 
-    return self:Put( data, wrapCb )
+    if self.access then
+        return self:Put( data, wrapCb )
+    end
+
+    table.insert( self._waitingForAccess, function()
+        self:Put( data, wrapCb )
+    end )
 end
 
 

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -205,7 +205,7 @@ cvars.AddChangeCallback( "express_domain_cl", function( _, _, new )
 end, "domain_check" )
 
 
-hook.Add( "OnExpressLoaded", "Express_HTTPInit", function()
+hook.Add( "ExpressLoaded", "Express_HTTPInit", function()
     hook.Add( "Tick", "Express_RevisionCheck", function()
         hook.Remove( "Tick", "Express_RevisionCheck" )
         if SERVER then express:Register() end

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -158,6 +158,13 @@ function express:_send( message, data, plys, onProof )
 end
 
 
+-- Assigns a callback to the given message --
+function express:_setReceiver( message, cb )
+    message = string.lower( message )
+    self._receivers[message] = cb
+end
+
+
 -- Returns the receiver set for the given message --
 function express:_getReceiver( message )
     message = string.lower( message )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,6 +4,7 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
+    util.AddNetworkString( "express_receiver_made" )
 end
 
 express = {}
@@ -15,12 +16,18 @@ express._maxDataSize = 24 * 1024 * 1024
 express._jsonHeaders = { ["Content-Type"] = "application/json" }
 express._bytesHeaders = { ["Accept"] = "application/octet-stream" }
 
+
 -- Registers a basic receiver --
 function express.Receive( message, cb )
     message = string.lower( message )
     express._receivers[message] = cb
-end
 
+    if SERVER then return end
+
+    net.Start( "express_receiver_made" )
+    net.WriteString( message )
+    net.SendToServer()
+end
 
 -- Registers a PreDownload receiver --
 function express.ReceivePreDl( message, preDl )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,7 +4,6 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
-    util.AddNetworkString( "express_loaded" )
 end
 
 express = {}

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -29,6 +29,14 @@ function express.Receive( message, cb )
     net.SendToServer()
 end
 
+
+-- Removes a receiver --
+function express.ClearReceiver( message )
+    message = string.lower( message )
+    express._receivers[message] = nil
+end
+
+
 -- Registers a PreDownload receiver --
 function express.ReceivePreDl( message, preDl )
     message = string.lower( message )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,7 +4,7 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
-    util.AddNetworkString( "express_receiver_made" )
+    util.AddNetworkString( "express_receivers_made" )
 end
 
 express = {}
@@ -15,19 +15,6 @@ express._preDlReceivers = {}
 express._maxDataSize = 24 * 1024 * 1024
 express._jsonHeaders = { ["Content-Type"] = "application/json" }
 express._bytesHeaders = { ["Accept"] = "application/octet-stream" }
-
-
--- Registers a basic receiver --
-function express.Receive( message, cb )
-    message = string.lower( message )
-    express._receivers[message] = cb
-
-    if SERVER then return end
-
-    net.Start( "express_receiver_made" )
-    net.WriteString( message )
-    net.SendToServer()
-end
 
 
 -- Removes a receiver --

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -71,6 +71,10 @@ function express:GetSize( id, cb )
         assert( sizeHolder, "Invalid JSON" )
 
         local size = sizeHolder.size
+        if not size then
+            print( "Express: Failed to get size for ID '" .. id .. "'.", code )
+            print( body )
+        end
         assert( size, "No size data" )
 
         cb( tonumber( size ) )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -162,7 +162,7 @@ function express.OnMessage( _, ply )
     end
 
     if express:_getPreDlReceiver( message ) then
-        return express:GetSize( id, makeRequest )
+        return express:_getSize( id, makeRequest )
     end
 
     makeRequest()

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -14,16 +14,6 @@ express._preDlReceivers = {}
 express._maxDataSize = 24 * 1024 * 1024
 express._jsonHeaders = { ["Content-Type"] = "application/json" }
 express._bytesHeaders = { ["Accept"] = "application/octet-stream" }
-express.domain = CreateConVar(
-    "express_domain", "gmod.express", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The domain of the Express server"
-)
-
--- Useful for self-hosting if you need to set express_domain to localhost
--- and direct clients to a global IP/domain to hit the same service
-express.domain_cl = CreateConVar(
-    "express_domain_cl", "", FCVAR_ARCHIVE + FCVAR_REPLICATED, "The client-specific domain of the Express server. If empty, express_domain will be used."
-)
-
 
 -- Registers a basic receiver --
 function express.Receive( message, cb )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,6 +4,7 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
+    util.AddNetworkString( "express_loaded" )
 end
 
 express = {}
@@ -202,3 +203,5 @@ if SERVER then
 else
     include( "cl_init.lua" )
 end
+
+hook.Run( "OnExpressLoaded" )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -208,4 +208,4 @@ else
     include( "cl_init.lua" )
 end
 
-hook.Run( "OnExpressLoaded" )
+hook.Run( "ExpressLoaded" )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -57,7 +57,7 @@ end
 
 -- Runs a hook when a player makes a new express Receiver --
 function express._onReceiverMade( _, ply )
-    local name = net.ReadString()
+    local name = string.lower( net.ReadString() )
     hook.Run( "OnExpressPlayerReceiver", ply, name )
 end
 

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -58,7 +58,7 @@ end
 -- Runs a hook when a player makes a new express Receiver --
 function express._onReceiverMade( _, ply )
     local name = string.lower( net.ReadString() )
-    hook.Run( "OnExpressPlayerReceiver", ply, name )
+    hook.Run( "ExpressPlayerReceiver", ply, name )
 end
 
 net.Receive( "express_receiver_made", express._onReceiverMade )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -55,9 +55,18 @@ function express:SetExpected( hash, cb, plys )
 end
 
 
+-- Runs a hook when a player has loaded Express --
 -- Send the player their access token as soon as it's safe to do so --
-hook.Add( "PlayerFullLoad", "Express_Access", function( ply )
+function express.OnPlayerLoaded( ply )
+    if ply.expressLoaded then return end
+
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
-end )
+
+    ply.expressLoaded = true
+
+    hook.Run( "OnPlayerLoadedExpress", ply )
+end
+
+net.Receive( "express_loaded", express.OnPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -66,7 +66,7 @@ function express.OnPlayerLoaded( ply )
 
     ply.expressLoaded = true
 
-    hook.Run( "OnPlayerLoadedExpress", ply )
+    hook.Run( "OnPlayerExpressLoaded", ply )
 end
 
 net.Receive( "express_loaded", express.OnPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -65,10 +65,10 @@ net.Receive( "express_receiver_made", express._onReceiverMade )
 
 
 -- Send the player their access token as soon as it's safe to do so --
-function express.OnPlayerLoaded( ply )
+function express._onPlayerLoaded( ply )
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
 end
 
-hook.Add( "PlayerFullLoad", "Express_PlayerReady", express.OnPlayerLoaded )
+hook.Add( "PlayerFullLoad", "Express_PlayerReady", express._onPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -1,6 +1,5 @@
 require( "playerload" )
 util.AddNetworkString( "express_access" )
-util.AddNetworkString( "express_receiver_made" )
 
 
 -- Broadcasts the given data to all connected players --

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -2,6 +2,12 @@ require( "playerload" )
 util.AddNetworkString( "express_access" )
 
 
+-- Registers a basic receiver --
+function express.Receive( message, cb )
+    express:_setReceiver( message, cb )
+end
+
+
 -- Broadcasts the given data to all connected players --
 function express.Broadcast( message, data, onProof )
     express.Send( message, data, player.GetAll(), onProof )
@@ -57,11 +63,15 @@ end
 
 -- Runs a hook when a player makes a new express Receiver --
 function express._onReceiverMade( _, ply )
-    local name = string.lower( net.ReadString() )
-    hook.Run( "ExpressPlayerReceiver", ply, name )
+    local messageCount = net.ReadUInt( 8 )
+
+    for _ = 1, messageCount do
+        local name = string.lower( net.ReadString() )
+        hook.Run( "ExpressPlayerReceiver", ply, name )
+    end
 end
 
-net.Receive( "express_receiver_made", express._onReceiverMade )
+net.Receive( "express_receivers_made", express._onReceiverMade )
 
 
 -- Send the player their access token as soon as it's safe to do so --

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -58,15 +58,11 @@ end
 -- Runs a hook when a player has loaded Express --
 -- Send the player their access token as soon as it's safe to do so --
 function express.OnPlayerLoaded( ply )
-    if ply.expressLoaded then return end
-
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
 
-    ply.expressLoaded = true
-
     hook.Run( "OnPlayerExpressLoaded", ply )
 end
 
-net.Receive( "express_loaded", express.OnPlayerLoaded )
+hook.Add( "PlayerFullLoad", "Express_PlayerReady", express.OnPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -55,8 +55,8 @@ function express:SetExpected( hash, cb, plys )
 end
 
 
--- Runs a hook when a player has loaded Express --
 -- Send the player their access token as soon as it's safe to do so --
+-- Also Runs a notification hook that a player is fully ready to receive Express messages --
 function express.OnPlayerLoaded( ply )
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -1,5 +1,6 @@
 require( "playerload" )
 util.AddNetworkString( "express_access" )
+util.AddNetworkString( "express_receiver_made" )
 
 
 -- Broadcasts the given data to all connected players --
@@ -55,14 +56,20 @@ function express:SetExpected( hash, cb, plys )
 end
 
 
+-- Runs a hook when a player makes a new express Receiver --
+function express._onReceiverMade( _, ply )
+    local name = net.ReadString()
+    hook.Run( "OnExpressPlayerReceiver", ply, name )
+end
+
+net.Receive( "express_receiver_made", express._onReceiverMade )
+
+
 -- Send the player their access token as soon as it's safe to do so --
--- Also Runs a notification hook that a player is fully ready to receive Express messages --
 function express.OnPlayerLoaded( ply )
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
-
-    hook.Run( "OnPlayerExpressLoaded", ply )
 end
 
 hook.Add( "PlayerFullLoad", "Express_PlayerReady", express.OnPlayerLoaded )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,6 +1,6 @@
 local function getHookName( ply )
-    local steamID = ply:SteamID64()
-    return "GM_FullLoad_" .. steamID
+    local steamID64 = ply:SteamID64()
+    return "GM_FullLoad_" .. steamID64
 end
 
 hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( spawnedPly )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,21 +1,13 @@
-local function getHookName( ply )
-    local steamID64 = ply:SteamID64()
-    return "GM_FullLoad_" .. steamID64
-end
+local load_queue = {}
 
-hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( spawnedPly )
-    local hookName = getHookName( spawnedPly )
-
-    hook.Add( "SetupMove", hookName, function( ply, _, cmd )
-        if ply ~= spawnedPly then return end
-        if cmd:IsForced() then return end
-
-        hook.Remove( "SetupMove", hookName )
-        hook.Run( "PlayerFullLoad", ply )
-    end )
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadQueue", function( ply )
+    load_queue[ply] = true
 end )
 
-hook.Add( "PlayerDisconnected", "GM_FullLoadCleanup", function( ply )
-    local hookName = getHookName( ply )
-    hook.Remove( "SetupMove", hookName )
+hook.Add( "SetupMove", "GM_FullLoadInit", function( ply, _, cmd )
+    if not loadQueue[ply] then return end
+    if cmd:IsForced() then return end
+
+    load_queue[ply] = nil
+    hook.Run( "PlayerFullLoad", ply )
 end )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,13 +1,13 @@
-local load_queue = {}
+local loadQueue = {}
 
 hook.Add( "PlayerInitialSpawn", "GM_FullLoadQueue", function( ply )
-    load_queue[ply] = true
+    loadQueue[ply] = true
 end )
 
 hook.Add( "SetupMove", "GM_FullLoadInit", function( ply, _, cmd )
     if not loadQueue[ply] then return end
     if cmd:IsForced() then return end
 
-    load_queue[ply] = nil
+    loadQueue[ply] = nil
     hook.Run( "PlayerFullLoad", ply )
 end )

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -556,6 +556,7 @@ return {
             end,
             cleanup = function( state )
                 express.access = state.original_access
+                express._waitingForAccess = {}
             end
         },
 

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -430,7 +430,7 @@ return {
         {
             name = "express._put rejects data that is too large",
             func = function( state )
-                state.original_access = express.access
+                state.original_access = state.original_access or express.access
                 state.original_maxDataSize = state.original_maxDataSize or express._maxDataSize
                 express._maxDataSize = 0
 
@@ -491,9 +491,12 @@ return {
         },
         {
             name = "express._put on success, calls given callback and stores response ID in cache",
-            func = function()
+            func = function( state )
                 -- Sanity check
                 expect( table.Count( express._putCache ) ).to.equal( 0 )
+
+                state.original_access = state.original_access or express.access
+                express.access = "access-token"
 
                 local mockData = "hello"
                 local mockId = "test-id"
@@ -514,8 +517,9 @@ return {
                 expect( express._putCache[mockHash] ).to.equal( mockId )
             end,
 
-            cleanup = function()
+            cleanup = function( state )
                 express._putCache = {}
+                express.access = state.original_access
             end
         },
 

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -523,7 +523,44 @@ return {
             end
         },
 
-        -- express._send
+        -- express:_getSize
+        {
+            name = "express:_getSize calls express:GetSize if access token is set",
+            func = function( state )
+                state.original_access = state.original_access or express.access
+                express.access = "access-token"
+
+                local getSizeStub = stub( express, "GetSize" )
+                express:_getSize( "id", stub() )
+
+                expect( getSizeStub ).was.called()
+            end,
+            cleanup = function( state )
+                express.access = state.original_access
+            end
+        },
+        {
+            name = "express:_getSize queues the GetSize call if access token is not set",
+            func = function( state )
+                -- Sanity check
+                expect( #express._waitingForAccess ).to.equal( 0 )
+
+                state.original_access = state.original_access or express.access
+                express.access = nil
+
+                local getSizeStub = stub( express, "GetSize" )
+                express:_getSize( "id", stub() )
+
+                expect( getSizeStub ).wasNot.called()
+                expect( #express._waitingForAccess ).to.equal( 1 )
+            end,
+            cleanup = function( state )
+                express.access = state.original_access
+            end
+        },
+
+
+        -- express:_send
         {
             name = "express._send calls _put with a callback that nets message info and does not set expected if no onProof was provided",
             func = function()

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -414,7 +414,7 @@ return {
                 local compress = stub( util, "Compress" ).returns( "hello" )
                 local putStub = stub( express, "Put" )
 
-                express:_put( "data", "callback" )
+                express:_put( { "data" }, "callback" )
 
                 expect( encode ).was.called()
                 expect( compress ).was.called()

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -353,7 +353,7 @@ return {
                 stub( express, "_getPreDlReceiver" ).returns( stub() )
                 stub( net, "ReadString" ).returnsSequence( { "test-message" } )
 
-                local getSizeStub = stub( express, "GetSize" )
+                local getSizeStub = stub( express, "_getSize" )
 
                 express:OnMessage()
 

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -42,15 +42,15 @@ return {
             end
         },
 
-        -- express._setReceiver
+        -- express:_setReceiver
         {
-            name = "express._setReceiver adds the given callback to the receivers table and normalizes the name",
+            name = "express:_setReceiver adds the given callback to the receivers table and normalizes the name",
             func = function( state )
                 state.original_receivers = table.Copy( express._receivers )
                 express._receivers = {}
 
                 local callback = stub()
-                express._setReceiver( "TEST-MESSAGE", callback )
+                express:_setReceiver( "TEST-MESSAGE", callback )
 
                 expect( express._receivers["test-message"] ).to.equal( callback )
             end,

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -58,6 +58,50 @@ return {
                 express._receivers = state.original_receivers
             end
         },
+        {
+            name = "express.Receive sends a net message on CLIENT",
+            func = function( state )
+                state.original_server = SERVER
+                state.original_client = CLIENT
+                _G.SERVER = false
+                _G.CLIENT = true
+
+                state.original_receivers = table.Copy( express._receivers )
+                express._receivers = {}
+
+                -- TODO: Add a was.calledWith here when it exists
+                stub( net, "Start" )
+                stub( net, "WriteString" )
+                local sendToServerStub = stub( net, "SendToServer" )
+
+                express.Receive( "TEST-MESSAGE", stub() )
+                expect( sendToServerStub ).was.called()
+            end,
+
+            cleanup = function( state )
+                _G.SERVER = state.original_server
+                _G.CLIENT = state.original_client
+                express._receivers = state.original_receivers
+            end
+        },
+
+        -- express.ClearReceiver
+        {
+            name = "express.ClearReceiver removes the callback for the given message and normalizes the name",
+            func = function( state )
+                state.original_receivers = table.Copy( express._receivers )
+                express._receivers = {}
+
+                express.Receive( "test-message", stub() )
+
+                express.ClearReceiver( "TEST-MESSAGE" )
+                expect( express._receivers["test-message"] ).toNot.exist()
+            end,
+
+            cleanup = function( state )
+                express._receivers = state.original_receivers
+            end
+        },
 
         -- express.ReceivePreDl
         {

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -42,15 +42,15 @@ return {
             end
         },
 
-        -- express.Receive
+        -- express._setReceiver
         {
-            name = "express.Receive adds the given callback to the receivers table and normalizes the name",
+            name = "express._setReceiver adds the given callback to the receivers table and normalizes the name",
             func = function( state )
                 state.original_receivers = table.Copy( express._receivers )
                 express._receivers = {}
 
                 local callback = stub()
-                express.Receive( "TEST-MESSAGE", callback )
+                express._setReceiver( "TEST-MESSAGE", callback )
 
                 expect( express._receivers["test-message"] ).to.equal( callback )
             end,

--- a/lua/tests/gm_express/sh_init.lua
+++ b/lua/tests/gm_express/sh_init.lua
@@ -38,6 +38,7 @@ return {
 
                 expect( net.Receivers["express"] ).to.exist()
                 expect( net.Receivers["express_proof"] ).to.exist()
+                expect( net.Receivers["express_receivers_made"] ).to.exist()
             end
         },
 
@@ -55,32 +56,6 @@ return {
             end,
 
             cleanup = function( state )
-                express._receivers = state.original_receivers
-            end
-        },
-        {
-            name = "express.Receive sends a net message on CLIENT",
-            func = function( state )
-                state.original_server = SERVER
-                state.original_client = CLIENT
-                _G.SERVER = false
-                _G.CLIENT = true
-
-                state.original_receivers = table.Copy( express._receivers )
-                express._receivers = {}
-
-                -- TODO: Add a was.calledWith here when it exists
-                stub( net, "Start" )
-                stub( net, "WriteString" )
-                local sendToServerStub = stub( net, "SendToServer" )
-
-                express.Receive( "TEST-MESSAGE", stub() )
-                expect( sendToServerStub ).was.called()
-            end,
-
-            cleanup = function( state )
-                _G.SERVER = state.original_server
-                _G.CLIENT = state.original_client
                 express._receivers = state.original_receivers
             end
         },


### PR DESCRIPTION
There can be timing issues for players loading into the server - the server may try to send an Express message before the Client has fully loaded the addon.

This PR adds hooks on both realms that alert users when it's safe to make new Receivers or to send Messages.

On SHARED:
 - **`ExpressLoaded()`**: The full Express code has loaded. `express.Receive` and `express.Send` are available. Runs exactly once on both realms.

On SERVER:
 - **`ExpressPlayerReceiver( player ply, string message )`**: Called when `ply` creates a new receiver for `message` (and, by extension, is ready for both `net` and `express` messages)


#### So new code might look like:
```lua
-- cl_init.lua
hook.Add( "ExpressLoaded", "LoadMyAddon", function()
    express.Receive( "test_message", function( data )
    end )
end )
```

```lua
-- sv_init.lua
hook.Add( "ExpressPlayerReceiver", "SendInitialData", function( ply, message )
    if message ~= "test_message" then return end
    express.Send( "test_message", initialData, ply )
end )
```


Thanks to @dotCore-off for the report!