### PR TITLE
Add a Receiver Queue

### DIFF
--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -12,3 +12,9 @@ end
 function express:SetExpected( hash, cb )
     self._awaitingProof[hash] = cb
 end
+
+
+hook.Add( "OnExpressLoaded", "Express_AlertReady", function()
+    net.Start( "express_loaded" )
+    net.SendToServer()
+end )

--- a/lua/gm_express/cl_init.lua
+++ b/lua/gm_express/cl_init.lua
@@ -12,9 +12,3 @@ end
 function express:SetExpected( hash, cb )
     self._awaitingProof[hash] = cb
 end
-
-
-hook.Add( "OnExpressLoaded", "Express_AlertReady", function()
-    net.Start( "express_loaded" )
-    net.SendToServer()
-end )

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -191,9 +191,10 @@ cvars.AddChangeCallback( "express_domain_cl", function( _, _, new )
 end, "domain_check" )
 
 
--- Tick is the earliest shared hook where HTTP is available
-hook.Add( "Tick", "Express_RevisionCheck", function()
-    hook.Remove( "Tick", "Express_RevisionCheck" )
-    if SERVER then express:Register() end
-    express:CheckRevision()
+hook.Run( "OnExpressLoaded", "Express_HTTPInit", function()
+    hook.Add( "Tick", "Express_RevisionCheck", function()
+        hook.Remove( "Tick", "Express_RevisionCheck" )
+        if SERVER then express:Register() end
+        express:CheckRevision()
+    end )
 end )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,7 +4,6 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
-    util.AddNetworkString( "express_loaded" )
 end
 
 express = {}

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -4,6 +4,7 @@ require( "pon" )
 if SERVER then
     util.AddNetworkString( "express" )
     util.AddNetworkString( "express_proof" )
+    util.AddNetworkString( "express_loaded" )
 end
 
 express = {}
@@ -199,3 +200,5 @@ if SERVER then
 else
     include( "cl_init.lua" )
 end
+
+hook.Run( "OnExpressLoaded" )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -55,9 +55,18 @@ function express:SetExpected( hash, cb, plys )
 end
 
 
+-- Runs a hook when a player has loaded Express --
 -- Send the player their access token as soon as it's safe to do so --
-hook.Add( "PlayerFullLoad", "Express_Access", function( ply )
+function express.OnPlayerLoaded( ply )
+    if ply.expressLoaded then return end
+
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
-end )
+
+    ply.expressLoaded = true
+
+    hook.Run( "OnPlayerLoadedExpress", ply )
+end
+
+net.Receive( "express_loaded", express.OnPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -66,7 +66,7 @@ function express.OnPlayerLoaded( ply )
 
     ply.expressLoaded = true
 
-    hook.Run( "OnPlayerLoadedExpress", ply )
+    hook.Run( "OnPlayerExpressLoaded", ply )
 end
 
 net.Receive( "express_loaded", express.OnPlayerLoaded )

--- a/lua/gm_express/sv_init.lua
+++ b/lua/gm_express/sv_init.lua
@@ -58,15 +58,11 @@ end
 -- Runs a hook when a player has loaded Express --
 -- Send the player their access token as soon as it's safe to do so --
 function express.OnPlayerLoaded( ply )
-    if ply.expressLoaded then return end
-
     net.Start( "express_access" )
     net.WriteString( express._clientAccess )
     net.Send( ply )
 
-    ply.expressLoaded = true
-
     hook.Run( "OnPlayerExpressLoaded", ply )
 end
 
-net.Receive( "express_loaded", express.OnPlayerLoaded )
+hook.Add( "PlayerFullLoad", "Express_PlayerReady", express.OnPlayerLoaded )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,6 +1,6 @@
 local function getHookName( ply )
-    local steamID = ply:SteamID64()
-    return "GM_FullLoad_" .. steamID
+    local steamID64 = ply:SteamID64()
+    return "GM_FullLoad_" .. steamID64
 end
 
 hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( spawnedPly )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,21 +1,13 @@
-local function getHookName( ply )
-    local steamID64 = ply:SteamID64()
-    return "GM_FullLoad_" .. steamID64
-end
+local load_queue = {}
 
-hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( spawnedPly )
-    local hookName = getHookName( spawnedPly )
-
-    hook.Add( "SetupMove", hookName, function( ply, _, cmd )
-        if ply ~= spawnedPly then return end
-        if cmd:IsForced() then return end
-
-        hook.Remove( "SetupMove", hookName )
-        hook.Run( "PlayerFullLoad", ply )
-    end )
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadQueue", function( ply )
+    load_queue[ply] = true
 end )
 
-hook.Add( "PlayerDisconnected", "GM_FullLoadCleanup", function( ply )
-    local hookName = getHookName( ply )
-    hook.Remove( "SetupMove", hookName )
+hook.Add( "SetupMove", "GM_FullLoadInit", function( ply, _, cmd )
+    if not loadQueue[ply] then return end
+    if cmd:IsForced() then return end
+
+    load_queue[ply] = nil
+    hook.Run( "PlayerFullLoad", ply )
 end )


### PR DESCRIPTION
This is an alternative solution for the problem presented in https://github.com/CFC-Servers/gm_express/pull/27


It includes the same event hooks, but it reduces the scope of the problem.

This PR adds a new Receiver queue that will queue received Express messages that don't yet have a Receiver. If/when a Receiver is added, it will process all waiting messages.

Messages will stay queued for 5 seconds, at which point they'll be removed from the queue and a (non-halting) error is thrown to alert you of a problem.
 

With this change, the only things you really need to worry about are:
 1. Can the client receive net messages at all yet (a standard Gmod problem)
 2. Can you add your express Receivers when your code loads (another standard Gmod problem)

To solve the first problem, you can use something like a [`PlayerFullLoad`](https://github.com/CFC-Servers/gm_playerload) hook, or use the convenient `OnExpressPlayerLoaded` hook included in this PR (which runs after the included `PlayerFullLoad` module runs its hook)

For the second issue, you can load your code later in the hook chain (Express is effectively loaded in `autorun`, so anything after `OnGamemodeLoaded` _should_ be safe?), or you can rely on the new `OnExpressLoaded` hook.