### PR TITLE
As-needed Compression

### DIFF
--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -127,10 +127,15 @@ function express:_put( data, cb )
         error( "Express: Tried to send empty data!" )
     end
 
-    data = util.Compress( pon.encode( data ) )
+    data = pon.encode( data )
 
     if #data > self._maxDataSize then
-        error( "Express: Data too large (" .. #data .. " bytes)" )
+        data = "<enc>" .. util.Compress( data )
+        assert( data, "Express: Failed to compress data!" )
+
+        if #data > self._maxDataSize then
+            error( "Express: Data too large (" .. #data .. " bytes)" )
+        end
     end
 
     local hash = util.SHA1( data )

--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -129,12 +129,13 @@ function express:_put( data, cb )
 
     data = pon.encode( data )
 
-    if #data > self._maxDataSize then
+    if string.len( data ) > self._maxDataSize then
         data = "<enc>" .. util.Compress( data )
         assert( data, "Express: Failed to compress data!" )
 
-        if #data > self._maxDataSize then
-            error( "Express: Data too large (" .. #data .. " bytes)" )
+        local dataLen = string.len( data )
+        if dataLen > self._maxDataSize then
+            error( "Express: Data too large (" .. dataLen .. " bytes)" )
         end
     end
 

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -39,14 +39,16 @@ function express:Get( id, cb )
         express._checkResponseCode( code )
 
         local hash = util.SHA1( body )
-        local encodedData = util.Decompress( body, self._maxDataSize )
 
-        if #encodedData == 0 then
-            error( "Express: Failed to decompress data for ID '" .. id .. "'." )
-        else
-            local decodedData = pon.decode( encodedData )
-            cb( decodedData, hash )
+        if string.StartWith( body, "<enc>" ) then
+            body = util.Decompress( string.sub( body, 6 ) )
+            if ( not body ) or #body == 0 then
+                error( "Express: Failed to decompress data for ID '" .. id .. "'." )
+            end
         end
+
+        local decodedData = pon.decode( body )
+        cb( decodedData, hash )
     end
 
     HTTP( {


### PR DESCRIPTION
`util.Compress` is _super_ slow with sizable payloads.

I believe that skipping compression is better in most cases, the only exceptions being:
 1. Clients with really slow internet struggling with slightly larger uploads _(max upload size is 22mb at the moment, so I don't think this is too big of a concern)_
 2. When the data would legitimately be too big to send without compression

To address that, this PR only `util.Compress`s the data if it would otherwise exceed the size limit, and does another check to verify that the compressed data is also within the size constraints.


**Note**: This PR uses some experimental GLuaTest syntax that I hope to get merged in the next couple of days, so this PR is blocked until then.