### PR TITLE
Add Retries and Send Delay

### DIFF
--- a/lua/gm_express/sh_helpers.lua
+++ b/lua/gm_express/sh_helpers.lua
@@ -148,7 +148,7 @@ function express:_put( data, cb )
 
     local cached = self._putCache[hash]
     if cached then
-        local cachedAt = cached.added
+        local cachedAt = cached.cachedAt
 
         if os.time() <= ( cachedAt + self._maxCacheTime ) then
             -- Force the callback to run asynchronously for consistency
@@ -161,7 +161,7 @@ function express:_put( data, cb )
     end
 
     local function wrapCb( id )
-        self._putCache[hash] = { id = id, added = os.time() }
+        self._putCache[hash] = { id = id, cachedAt = os.time() }
         cb( id, hash )
     end
 

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -38,10 +38,11 @@ function express:Get( id, cb, _attempts )
 
     local success = function( code, body )
         if code == 404 then
-            assert( _attempts <= 5, "express:Get() failed to retrieve data after 5 attempts: " .. id )
+            assert( _attempts <= 20, "express:Get() failed to retrieve data after 20 attempts: " .. id )
             timer.Simple( 0.1 * _attempts, function()
                 self:Get( id, cb, _attempts + 1 )
             end )
+            return
         end
 
         express._checkResponseCode( code )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -38,8 +38,8 @@ function express:Get( id, cb, _attempts )
 
     local success = function( code, body )
         if code == 404 then
-            assert( _attempts <= 25, "express:Get() failed to retrieve data after 20 attempts: " .. id )
-            timer.Simple( 0.1 * _attempts, function()
+            assert( _attempts <= 25, "express:Get() failed to retrieve data after 25 attempts: " .. id )
+            timer.Simple( 0.125 * _attempts, function()
                 self:Get( id, cb, _attempts + 1 )
             end )
             return
@@ -50,8 +50,6 @@ function express:Get( id, cb, _attempts )
             print( "express:Get() succeeded after " .. _attempts .. " attempts: " .. id )
         end
 
-        local hash = util.SHA1( body )
-
         if string.StartWith( body, "<enc>" ) then
             body = util.Decompress( string.sub( body, 6 ) )
             if ( not body ) or #body == 0 then
@@ -59,6 +57,7 @@ function express:Get( id, cb, _attempts )
             end
         end
 
+        local hash = util.SHA1( body )
         local decodedData = pon.decode( body )
         cb( decodedData, hash )
     end

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -38,7 +38,7 @@ function express:Get( id, cb, _attempts )
 
     local success = function( code, body )
         if code == 404 then
-            assert( _attempts <= 20, "express:Get() failed to retrieve data after 20 attempts: " .. id )
+            assert( _attempts <= 25, "express:Get() failed to retrieve data after 20 attempts: " .. id )
             timer.Simple( 0.1 * _attempts, function()
                 self:Get( id, cb, _attempts + 1 )
             end )

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -592,34 +592,11 @@ return {
 
         -- express:_send
         {
-            name = "express._send calls _put with a callback that nets message info and does not set expected if no onProof was provided",
+            name = "express._send calls _putCallback",
             func = function()
-                stub( net, "Start" )
-                stub( net, "WriteString" )
-                stub( net, "WriteBool" )
+                local putCallback = stub()
+                stub( express, "_putCallback" ).returns( putCallback )
 
-                local setExpected = stub( express, "SetExpected" )
-                local shSend = stub( express, "shSend" )
-                local putStub = stub( express, "_put" ).with( function( _, _, cb )
-                    cb( "test-id", "test-hash" )
-                end )
-
-                express:_send( "test-message", "test-data", {} )
-
-                expect( putStub ).was.called()
-                expect( setExpected ).wasNot.called()
-                expect( shSend ).was.called()
-            end
-        },
-        {
-            name = "express._send calls _put with a callback that nets message info and sets expected if onProof was provided",
-            func = function()
-                stub( net, "Start" )
-                stub( net, "WriteString" )
-                stub( net, "WriteBool" )
-
-                local setExpected = stub( express, "SetExpected" )
-                local shSend = stub( express, "shSend" )
                 local putStub = stub( express, "_put" ).with( function( _, _, cb )
                     cb( "test-id", "test-hash" )
                 end )
@@ -627,8 +604,7 @@ return {
                 express:_send( "test-message", "test-data", {}, stub() )
 
                 expect( putStub ).was.called()
-                expect( setExpected ).was.called()
-                expect( shSend ).was.called()
+                expect( putCallback ).was.called()
             end
         },
 

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -499,7 +499,10 @@ return {
                 local mockCallback = stub()
                 local putStub = stub( express, "Put" )
 
-                express._putCache[mockHash] = mockId
+                express._putCache[mockHash] = {
+                    id = mockId,
+                    cachedAt = os.time()
+                }
 
                 stub( pon, "encode" ).returns( "encoded-data" )
                 stub( util, "Compress" ).returns( mockData )
@@ -543,7 +546,10 @@ return {
 
                 expect( putStub ).was.called()
                 expect( mockCallback ).was.called()
-                expect( express._putCache[mockHash] ).to.equal( mockId )
+
+                local actualCached = express._putCache[mockHash]
+                expect( actualCached ).to.exist()
+                expect( actualCached.id ).to.equal( mockId )
             end,
 
             cleanup = function( state )


### PR DESCRIPTION
Addresses the issues posed in #33 by delaying the Sender's net message by 1/10th of a second, and adds a retries system for Recipient GETs