### PR TITLE
Add "small message" net fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,14 @@ Very much like `express.Receive`, except this callback runs _before_ the `data` 
     - On <img src="https://user-images.githubusercontent.com/7936439/200705060-b5e57f56-a5a1-4c95-abfa-0d568be0aad6.png" width="15"> **CLIENT**, this callback receives:
         - **`string name`**: The name of the message
         - **`string id`**: The ID of the download _(used to retrieve the data from the API)_
+            - (**Note:** May be `""` for messages with small payloads)
         - **`int size`**: The size (in bytes) of the data
         - **`boolean needsProof`**: A boolean indicating whether or not the sender has requested proof-of-download
     - On <img src="https://user-images.githubusercontent.com/7936439/200705110-55b19d08-b342-4e94-a7c3-6b45baf98c2b.png" width="15"> **SERVER**, this callback receives:
         - **`string name`**: The name of the message
         - **`Player ply`**: The player that is sending the data
         - **`string id`**: The ID of the download _(used to retrieve the data from the API)_
+            - (**Note:** May be `""` for messages with small payloads)
         - **`int size`**: The size (in bytes) of the data
         - **`boolean needsProof`**: A boolean indicating whether or not the sender has requested proof-of-download
 

--- a/lua/autorun/gm_express_init.lua
+++ b/lua/autorun/gm_express_init.lua
@@ -1,2 +1,3 @@
 AddCSLuaFile( "includes/modules/pon.lua" )
 include( "gm_express/sh_init.lua" )
+print( "express loaded" )

--- a/lua/gm_express/sh_init.lua
+++ b/lua/gm_express/sh_init.lua
@@ -14,7 +14,7 @@ express._receivers = {}
 express._protocol = "http"
 express._awaitingProof = {}
 express._preDlReceivers = {}
-express._minDataSize = 63 * 102
+express._minDataSize = 63 * 1024
 express._maxDataSize = 24 * 1024 * 1024
 express._jsonHeaders = { ["Content-Type"] = "application/json" }
 express._bytesHeaders = { ["Accept"] = "application/octet-stream" }
@@ -229,6 +229,7 @@ end
 
 -- The callback for messages that could already fit in a net message --
 function express.OnSmall( _, ply )
+    print( "received small message" )
     local message = net.ReadString()
 
     -- TODO: Include sender information for Server, share with OnMessage
@@ -240,6 +241,7 @@ function express.OnSmall( _, ply )
     local dataLen = net.ReadUInt( 16 )
 
     if express:_getPreDlReceiver( message ) then
+        print( "calling preDl receiver for small message", message )
         local check = express:CallPreDownload( message, ply, "", dataLen, needsProof )
         if check == false then return end
     end

--- a/lua/tests/gm_express/sh_helpers.lua
+++ b/lua/tests/gm_express/sh_helpers.lua
@@ -619,13 +619,15 @@ return {
             name = "express._getReceiver returns the valid receiver for the given message",
             func = function( state )
                 state.original_receivers = state.original_receivers or express._receivers
+
+                local cb = function() end
                 express._receivers = {
-                    ["test-message"] = "test-receiver"
+                    ["test-message"] = cb
                 }
 
                 local receiver = express:_getReceiver( "test-message" )
 
-                expect( receiver ).to.equal( "test-receiver" )
+                expect( receiver ).to.equal( cb )
             end,
             cleanup = function( state )
                 express._receivers = state.original_receivers
@@ -635,13 +637,15 @@ return {
             name = "express._getReceiver returns the valid receiver for the given message, regardless of casing",
             func = function( state )
                 state.original_receivers = state.original_receivers or express._receivers
+
+                local cb = function() end
                 express._receivers = {
-                    ["test-message"] = "test-receiver"
+                    ["test-message"] = cb
                 }
 
                 local receiver = express:_getReceiver( "TEST-MESSAGE" )
 
-                expect( receiver ).to.equal( "test-receiver" )
+                expect( receiver ).to.equal( cb )
             end,
             cleanup = function( state )
                 express._receivers = state.original_receivers
@@ -667,13 +671,15 @@ return {
             name = "express._getPreDlReceiver returns the valid receiver for the given message",
             func = function( state )
                 state.original_preDlReceivers = state.original_preDlReceivers or express._preDlReceivers
+
+                local cb = function() end
                 express._preDlReceivers = {
-                    ["test-message"] = "test-receiver"
+                    ["test-message"] = cb
                 }
 
                 local receiver = express:_getPreDlReceiver( "test-message" )
 
-                expect( receiver ).to.equal( "test-receiver" )
+                expect( receiver ).to.equal( cb )
             end,
             cleanup = function( state )
                 express._preDlReceivers = state.original_preDlReceivers
@@ -683,13 +689,15 @@ return {
             name = "express._getPreDlReceiver returns the valid receiver for the given message, regardless of casing",
             func = function( state )
                 state.original_preDlReceivers = state.original_preDlReceivers or express._preDlReceivers
+
+                local cb = function() end
                 express._preDlReceivers = {
-                    ["test-message"] = "test-receiver"
+                    ["test-message"] = cb
                 }
 
                 local receiver = express:_getPreDlReceiver( "TEST-MESSAGE" )
 
-                expect( receiver ).to.equal( "test-receiver" )
+                expect( receiver ).to.equal( cb )
             end,
             cleanup = function( state )
                 express._preDlReceivers = state.original_preDlReceivers


### PR DESCRIPTION
After our latest [performance tests](https://github.com/CFC-Servers/gm_express#performance), it became clear that Express performs poorly for small messages.
But we already knew that, Express wasn't made to send small messages - no big surprise.

Well, based on our current per-key storage metrics, people are sending tons very small messages using Express. Unfortunately with messages this small, their experience will be exclusively worse than if they had just used a net message.

The performance tests highlighted another important thing: Express is only worse for messages that require 3 or fewer net messages.

This is interesting. If we look at both the usage metrics and the performance results, we find a cheap way to improve Express.

I don't necessarily want to make a pure-net data sender, but we could pretty easily cover the situation where a message could fit into a single net message.

That's what this PR does; it redirects small message payloads through the net library instead of the Express API, while still behaving the same way (calling receivers, respecting preDl receivers handling proofs, etc.).

I want to take this opportunity to refactor a few things and slim down the code, so the diff will be large but the functional changes will be few.

I also need to decide what to use as the `id` for these "small" messages in the callback chain. (some callbacks want the item ID). I don't want to introduce a regression, but I also don't want to write any worse code...